### PR TITLE
Fix Lambda Docker Image: Move Assets and Set Correct Handler

### DIFF
--- a/deployment/aws/lambda/Dockerfile
+++ b/deployment/aws/lambda/Dockerfile
@@ -21,5 +21,5 @@ RUN rm -rdf /asset/numpy/doc/ /asset/boto3* /asset/botocore* /asset/bin /asset/g
 RUN yum remove -y gcc-c++
 
 COPY lambda/handler.py /asset/handler.py
-
-CMD ["echo", "hello world"]
+RUN mv /asset/* ${LAMBDA_TASK_ROOT}/
+CMD ["handler.handler"]


### PR DESCRIPTION
This pull request fixes an issue with the AWS Lambda Docker image configuration in the titiler repository. The current Dockerfile uses a placeholder CMD that only echoes "hello world", which means the Lambda function code is never executed.

Changes Proposed:

Move Assets: Adds the command RUN mv /asset/* ${LAMBDA_TASK_ROOT}/ to move all asset files into the Lambda task root directory, ensuring that the function code is correctly located.
Set Handler: Updates the CMD instruction to CMD ["handler.handler"] so that AWS Lambda calls the handler function defined in handler.py.
Rationale:

AWS Lambda requires that the function code be placed in the directory specified by ${LAMBDA_TASK_ROOT} and that the handler is set to the proper entry point. Without these changes, the container would not execute the intended code when deployed on Lambda.

Testing:

The changes have been tested locally using the Lambda runtime interface emulator, and the function now executes as expected.

Please review and merge this update to improve the Lambda deployment experience.